### PR TITLE
feat: Add docker buildx

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,10 @@
 kind: pipeline
 name: default
 
+platform:
+  os: linux
+  arch: amd64
+
 steps:
 - name: conform
   image: autonomy/conform:c539351

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
 FROM alpine:3.9
-RUN apk add --update make docker go musl-dev bash curl git jq
-RUN go get github.com/talos-systems/gitmeta \
-    && mv /root/go/bin/gitmeta /usr/local/bin/
+
+RUN apk add --update --no-cache make musl-dev bash curl git jq
+
+RUN curl --create-dirs -Lo /root/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.2.2/buildx-v0.2.2.linux-amd64 \
+    && chmod 755 /root/.docker/cli-plugins/docker-buildx
+
+RUN curl --create-dirs -Lo /usr/local/bin/gitmeta https://github.com/talos-systems/gitmeta/releases/download/v0.1.0-alpha.0/gitmeta-linux-amd64 \
+    && chmod 755 /usr/local/bin/gitmeta
+
 RUN curl -o /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
     && curl -LO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk \
     && apk add glibc-2.29-r0.apk \
     && rm glibc-2.29-r0.apk
+
 # Required by docker-compose for zlib.
 ENV LD_LIBRARY_PATH=/lib:/usr/lib
-COPY --from=docker/compose:1.23.2 /usr/local/bin/docker-compose /usr/local/bin/
-COPY --from=docker:18.09.4 /usr/local/bin/docker /usr/local/bin/
+
+COPY --from=docker/compose:1.24.0 /usr/local/bin/docker-compose /usr/local/bin/
+COPY --from=docker:19.03-rc /usr/local/bin/docker /usr/local/bin/dockerd /usr/local/bin/
 COPY --from=moby/buildkit:v0.5.0 /usr/bin/buildctl /usr/local/bin/


### PR DESCRIPTION
- Adds docker buildx command 
- Upgrade docker to 19.03 rc to support buildx
- Clean up initial base layer ( remove go )
- Download gitmeta binary instead of compile on the fly

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>