### PR TITLE
chore: Update component versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.9
 RUN apk add --update --no-cache make musl-dev bash curl git jq
 
-RUN curl --create-dirs -Lo /root/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.2.2/buildx-v0.2.2.linux-amd64 \
+RUN curl --create-dirs -Lo /root/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.3.0/buildx-v0.3.0.linux-amd64 \
     && chmod 755 /root/.docker/cli-plugins/docker-buildx
 
-RUN curl --create-dirs -Lo /usr/local/bin/gitmeta https://github.com/talos-systems/gitmeta/releases/download/v0.1.0-alpha.0/gitmeta-linux-amd64 \
+RUN curl --create-dirs -Lo /usr/local/bin/gitmeta https://github.com/talos-systems/gitmeta/releases/download/v0.1.0-alpha.2/gitmeta-linux-amd64 \
     && chmod 755 /usr/local/bin/gitmeta
 
 RUN curl -o /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
@@ -15,7 +15,7 @@ RUN curl -o /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sger
 # Required by docker-compose for zlib.
 ENV LD_LIBRARY_PATH=/lib:/usr/lib
 
-COPY --from=docker/compose:1.24.0 /usr/local/bin/docker-compose /usr/local/bin/
-COPY --from=docker:19.03-rc /usr/local/bin/docker /usr/local/bin/dockerd /usr/local/bin/
-COPY --from=moby/buildkit:v0.5.0 /usr/bin/buildctl /usr/local/bin/
+COPY --from=docker/compose:1.24.1 /usr/local/bin/docker-compose /usr/local/bin/
+COPY --from=docker:19.03.1 /usr/local/bin/docker /usr/local/bin/dockerd /usr/local/bin/
+COPY --from=moby/buildkit:v0.6.1 /usr/bin/buildctl /usr/local/bin/
 COPY --from=autonomy/bldr:946e61b-scratch /bldr /usr/local/bin/


### PR DESCRIPTION
- Update docker/buildx 0.2.2 -> 0.3.0
- Update docker/compose 1.24.0 -> 1.24.1
- Update docker/docker 19.03-rc -> 19.03.1
- Update moby/buildkit 0.5.0 -> 0.6.1
- Update gitmeta alpha.0 -> alpha.2

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>