### PR TITLE
chore: bump gitmeta to 0.1.0-alpha3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM $BLDR as bldr
 FROM alpine:3.9
 
 ENV BUILDX_VERSION=v0.3.0
-ENV GITMETA_VERSION=v0.1.0-alpha.2
+ENV GITMETA_VERSION=v0.1.0-alpha.3
 ENV CLOUD_SDK_VERSION=258.0.0
 
 # janky janky janky


### PR DESCRIPTION
Release: https://github.com/talos-systems/gitmeta/releases/tag/v0.1.0-alpha.3

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>