### PR TITLE
chore: add `xz` for upcoming Firecracker "bootloader"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN apk add --update --no-cache \
   python2 \
   python2-dev \
   iptables \
-  ip6tables
+  ip6tables \
+  xz
 
 # Install docker buildx
 ADD buildx/bin/buildx /root/.docker/cli-plugins/docker-buildx


### PR DESCRIPTION
Linux `bzImage` is using some version of `xz` compression which no
native golang `xz` library can decompress.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>