### PR TITLE
chore: use Firecracker 0.21 release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,11 +34,6 @@ steps:
       - cd buildx
       - git checkout 709ef36b4f10a9389fd9a806657c48a969909d85
       - make binaries
-      - cd ..
-      - git clone https://github.com/firecracker-microvm/firecracker.git
-      - cd firecracker
-      - git checkout 7ecb2321fb3086f4b615dc8cd84a06efacee2c2f
-      - tools/devtool -y build
     volumes:
       - name: docker-socket
         path: /var/run

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV BUILDX_VERSION=v0.3.0
 ENV GITMETA_VERSION=v0.1.0-alpha.3
 ENV CLOUD_SDK_VERSION=258.0.0
 ENV CNI_PLUGINS_VERSION=v0.8.5
+ENV FIRECRACKER_VERSION=v0.21.0
 
 # janky janky janky
 ENV PATH /google-cloud-sdk/bin:$PATH
@@ -81,7 +82,8 @@ RUN curl -LO https://github.com/containernetworking/plugins/releases/download/${
   rm cni-plugins-linux-amd64-${CNI_PLUGINS_VERSION}.tgz
 
 # Install firecracker
-ADD firecracker/build/cargo_target/x86_64-unknown-linux-musl/debug/firecracker /usr/bin/firecracker
+RUN curl -Lo /usr/local/bin/firecracker https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}-x86_64 \
+  && chmod 755 /usr/local/bin/firecracker
 
 # Required by docker-compose for zlib.
 ENV LD_LIBRARY_PATH=/lib:/usr/lib


### PR DESCRIPTION
Release notes: https://github.com/firecracker-microvm/firecracker/releases/tag/v0.21.0

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>