### PR TITLE
chore: add helper scripts to set up amd64/arm64 builders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,9 @@ RUN curl -Lo /usr/local/bin/firecracker https://github.com/firecracker-microvm/f
 # Required by docker-compose for zlib.
 ENV LD_LIBRARY_PATH=/lib:/usr/lib
 
+# Install custom scripts
+ADD hack/scripts/ /usr/local/bin
+
 COPY --from=docker_compose /usr/local/bin/docker-compose /usr/local/bin/
 COPY --from=docker /usr/local/bin/docker /usr/local/bin/dockerd /usr/local/bin/
 COPY --from=buildkit /usr/bin/buildctl /usr/local/bin/

--- a/hack/scripts/install-ci-key
+++ b/hack/scripts/install-ci-key
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eou pipefail
+
+if [ -z "${SSH_KEY+x}" ]; then
+    exit 0
+fi
+
+mkdir -p ~/.ssh
+echo "${SSH_KEY}" | base64 -d > ~/.ssh/id_ed25519
+chmod 400 ~/.ssh/id_ed25519
+
+echo "Host 139.178.90.2" >> ~/.ssh/config
+echo "  User root" >> ~/.ssh/config
+echo "  StrictHostKeyChecking no" >> ~/.ssh/config

--- a/hack/scripts/setup-buildx-amd64-arm64
+++ b/hack/scripts/setup-buildx-amd64-arm64
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eou pipefail
+
+docker buildx create --driver docker-container --platform linux/amd64 --name xbuild --config hack/buildkit.conf --use
+docker buildx create --append --name xbuild ssh://139.178.90.2 --platform linux/arm64


### PR DESCRIPTION
This will be used temporarily at least for bldr and bldr-based projects
to bootstrap arm64 toolchain and packages.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>