### PR TITLE
chore: remove hack/buildkit.conf

### DIFF
--- a/hack/scripts/setup-buildx-amd64-arm64
+++ b/hack/scripts/setup-buildx-amd64-arm64
@@ -2,5 +2,5 @@
 
 set -eou pipefail
 
-docker buildx create --driver docker-container --platform linux/amd64 --name xbuild --config hack/buildkit.conf --use
+docker buildx create --driver docker-container --platform linux/amd64 --name xbuild --use
 docker buildx create --append --name xbuild ssh://139.178.90.2 --platform linux/arm64


### PR DESCRIPTION
It was specific to bldr and related to registry.ci.svc,
we don't neet it for now.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>