### PR TITLE
test: add qemu and libvirt packages into container

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,6 @@
 kind: pipeline
 name: default
+type: kubernetes
 
 platform:
   os: linux

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ RUN curl -LO https://github.com/containernetworking/plugins/releases/download/${
 RUN curl -Lo /usr/local/bin/firecracker https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}-x86_64 \
   && chmod 755 /usr/local/bin/firecracker
 
+# Install QEMU
+RUN apk add qemu-img qemu-system-x86_64
+
 # Required by docker-compose for zlib.
 ENV LD_LIBRARY_PATH=/lib:/usr/lib
 


### PR DESCRIPTION
QEMU executable is required to run e2e functional tests.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>