### PR TITLE
chore: add buildkit.conf as a file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,8 @@ RUN curl --create-dirs -Lo /root/.docker/cli-plugins/docker-buildx https://githu
   && chmod 755 /root/.docker/cli-plugins/docker-buildx
 
 # Install custom scripts
-ADD hack/scripts/ /usr/local/bin
+ADD hack/scripts/ /usr/local/bin/
+ADD hack/buildkit.conf /usr/local/etc/
 
 RUN curl -Lo /usr/local/bin/git-chglog https://github.com/git-chglog/git-chglog/releases/download/${GIT_CHGLOG_VERSION}/git-chglog_linux_amd64
 RUN chmod +x /usr/local/bin/git-chglog

--- a/hack/buildkit.conf
+++ b/hack/buildkit.conf
@@ -1,0 +1,4 @@
+[registry."registry.ci.svc:5000"]
+http = true
+insecure = true
+mirrors = "registry.ci.svc:5000"


### PR DESCRIPTION
This config can be used to whitelist registry.ci.svc as insecure
registry.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>