### PR TITLE
fix: update builkit.conf, move default xbuild builder to new docker

### DIFF
--- a/hack/buildkit.conf
+++ b/hack/buildkit.conf
@@ -1,4 +1,4 @@
 [registry."registry.ci.svc:5000"]
 http = true
 insecure = true
-mirrors = "registry.ci.svc:5000"
+mirrors = ["registry.ci.svc:5000"]

--- a/hack/scripts/setup-buildx-amd64-arm64
+++ b/hack/scripts/setup-buildx-amd64-arm64
@@ -3,4 +3,4 @@
 set -eou pipefail
 
 docker buildx create --driver docker-container --platform linux/amd64 --name xbuild --use
-docker buildx create --append --name xbuild ssh://139.178.90.2 --platform linux/arm64
+docker buildx create --append --name xbuild --platform linux/arm64 tcp://docker-arm64.ci.svc:2376


### PR DESCRIPTION
`xbuild` is used by default in toolchain, tools, pkgs

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>