### PR TITLE
chore: upgrade Docker to the latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DOCKER=docker:19.03.12
+ARG DOCKER=docker:19.03.13
 ARG BUILDKIT=moby/buildkit:v0.7.1
 ARG GOLANG=golang:1.14-alpine
 


### PR DESCRIPTION
19.03.13 is the latest version, this should hopefully pull newer buildx
version.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>