### PR TITLE
feat: add setup-ci script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,3 +98,5 @@ RUN chmod +x /usr/local/bin/git-chglog
 COPY --from=docker /usr/local/bin/docker /usr/local/bin/dockerd /usr/local/bin/
 COPY --from=buildkit /usr/bin/buildctl /usr/local/bin/
 COPY --from=tc-redirect-tap /opt/cni/bin/tc-redirect-tap /opt/cni/bin/
+
+RUN apk add --no-cache coreutils

--- a/hack/scripts/setup-ci
+++ b/hack/scripts/setup-ci
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+export TAG=$(git log --oneline --format=%B -n 1 HEAD | head -n 1 | sed -r "s/^release\((.*)\):.*$/\\1/")
+
+function setup_buildkit() {
+  local COMMON_ARGS="--name ci --buildkitd-flags '--allow-insecure-entitlement security.insecure' --driver-opt image=moby/buildkit:master"
+
+  docker buildx create \
+    $COMMON_ARGS \
+    --platform linux/amd64 \
+    --driver docker-container  \
+    --use unix:///var/outer-run/docker.sock
+
+  docker buildx create \
+    $COMMON_ARGS \
+    --platform linux/arm64 \
+    --append \
+    tcp://docker-arm64.ci.svc:2376
+
+  docker buildx inspect --bootstrap
+}
+
+
+function setup_tags() {
+  git fetch --tags
+
+  if [ -n $TAG ]; then
+    echo "Creating temporary tag $TAG"
+    git tag -a $TAG -m "$TAG"
+  fi
+}
+
+sleep 5
+setup_buildkit
+setup_tags


### PR DESCRIPTION
A helper script for setting up buildkit and git tags.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
