### PR TITLE
chore: add git-lfs to build-container

### DIFF
--- a/hack/buildkit.conf
+++ b/hack/buildkit.conf
@@ -1,4 +1,0 @@
-[registry."registry.ci.svc:5000"]
-http = true
-insecure = true
-mirrors = ["registry.ci.svc:5000"]


### PR DESCRIPTION
`pkgs` repo has LFS enabled, and `git-lfs` is required for correct
status.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>