### PR TITLE
fix: release build depends on `sed` features not available in busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apk add --update --no-cache \
   python3 \
   python3-dev \
   rust \
+  sed \
   tar \
   qemu-img \
   qemu-system-aarch64 \


### PR DESCRIPTION
Install sed explicitly.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>