### PR TITLE
chore: use forked buildkit image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM $DOCKER as docker
 FROM alpine:3.14
 
 ARG CLOUD_SDK_VERSION=353.0.0
-ARG BUILDX=v0.6.1
+ARG BUILDX=v0.6.3
 ARG GIT_CHGLOG_VERSION=0.9.1
 
 # janky janky janky

--- a/hack/scripts/setup-ci
+++ b/hack/scripts/setup-ci
@@ -4,18 +4,33 @@ set -ex
 
 export TAG=$(git log --oneline --format=%B -n 1 HEAD | head -n 1 | sed -r "/^release\(/ s/^release\((.*)\):.*$/\\1/; t; Q")
 
+# temp override, see https://github.com/moby/buildkit/pull/2394
+BUILDKIT_IMAGE="ghcr.io/smira/buildkit:cap-fix"
+
+# setup buildkit across amd64/arm64 workers
 function setup_buildkit() {
   docker buildx create \
-    --name ci --buildkitd-flags "--allow-insecure-entitlement security.insecure" --driver-opt image=moby/buildkit:buildx-stable-1 \
+    --name ci --buildkitd-flags "--allow-insecure-entitlement security.insecure" --driver-opt image=${BUILDKIT_IMAGE} \
     --platform linux/amd64 \
     --driver docker-container  \
     --use unix:///var/outer-run/docker.sock
 
   docker buildx create \
-    --name ci --buildkitd-flags "--allow-insecure-entitlement security.insecure" --driver-opt image=moby/buildkit:buildx-stable-1 \
+    --name ci --buildkitd-flags "--allow-insecure-entitlement security.insecure" --driver-opt image=${BUILDKIT_IMAGE} \
     --platform linux/arm64 \
     --append \
     tcp://docker-arm64.ci.svc:2376
+
+  docker buildx inspect --bootstrap
+}
+
+# setup buildkit on amd64 builder only with QEMU emulation for arm64
+function setup_buildkit_cross() {
+  docker buildx create \
+    --name ci --buildkitd-flags "--allow-insecure-entitlement security.insecure" --driver-opt image=${BUILDKIT_IMAGE} \
+    --platform linux/amd64,linux/arm64 \
+    --driver docker-container  \
+    --use unix:///var/outer-run/docker.sock
 
   docker buildx inspect --bootstrap
 }
@@ -36,5 +51,15 @@ function setup_tags() {
 }
 
 sleep 5
+
+case "${BUILDKIT_FLAVOR:-default}" in
+  cross)
+    setup_buildkit_cross
+    ;;
+  *)
+    setup_buildkit
+    ;;
+esac
+
 setup_buildkit
 setup_tags


### PR DESCRIPTION
This workarounds an issue with entitlements.

Also provide a way to boot amd64-only buildkit worker (to be used later
in Talos to speed up builds).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>